### PR TITLE
Various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,7 @@ puppet-newrelic - New Relic Server Monitor
 This puppet module will install New Relic's FREE Server monitor
 agent on your servers.
 
-Currently this module  supports rpm-based distributions like rhel/centos by
-default and has specific support for Ubuntu/Debian (module "apt" needed as a
-dependency).
-Patches for other distributions are welcome.
+This module supports yum and apt-based distributions
 
 Installation
 ------------
@@ -15,17 +12,10 @@ Installation
 1. Sign up for an account at http://newrelic.com/signup if you
    haven't yet.
 2. Copy this directory to your puppet master module path
-3. Set your license key in the `$license_key` var in the `server.pp` file.
-4. Apply the `newrelic` class to any nodes you want the agent installed on.
+3. Set $newrelic_license and apply the `newrelic` class to any nodes you want the agent installed on:
 5. Login to your New Relic dashboard and you should see your servers show up
    in a few minutes.
 
-Todo
-----
-
-- Add support for .deb based systems.  Pull requests very welcome on this
-  since I don't currently run any debian-based systems.
-  
 Contributing
 ------------
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,31 +1,34 @@
 class newrelic::repo {
-  case $operatingsystem {
-    /Debian|Ubuntu/: {
-      include apt
-      apt::key {"548C16BF":
-        source => "http://download.newrelic.com/548C16BF.gpg",
-      }
-      apt::sources_list {"newrelic":
-        ensure  => "present",
-        content => "deb http://apt.newrelic.com/debian/ newrelic non-free",
-        notify => Exec["apt-get_update"],
-        require => Apt::Key["548C16BF"],
-      }  
-    }
-    default: { 
-      file { "/etc/pki/rpm-gpg/RPM-GPG-KEY-NewRelic":
-          owner   => root,
-          group   => root,
-          mode    => 0644,
-          source  => "puppet:///newrelic/RPM-GPG-KEY-NewRelic";
-      }
+    case $operatingsystem {
+        /Debian|Ubuntu/: {
+            exec { newrelic-add-apt-key:
+                unless  => "apt-key list | grep -q 1024D/548C16BF",
+                command => "apt-key adv --keyserver hkp://subkeys.pgp.net --recv-keys 548C16BF",
+            }
+            exec { newrelic-add-apt-repo:
+                creates => "/etc/apt/sources.list.d/newrelic.list",
+                command => "wget -O /etc/apt/sources.list.d/newrelic.list http://download.newrelic.com/debian/newrelic.list",
+            }
+            exec { newrelic-apt-get-update:
+                refreshonly => true,
+                subscribe   => [Exec["newrelic-add-apt-key"], Exec["newrelic-add-apt-repo"]],
+                command     => "apt-get update",
+            }
+        }
+        default: {
+            file { "/etc/pki/rpm-gpg/RPM-GPG-KEY-NewRelic":
+                owner   => root,
+                group   => root,
+                mode    => 0644,
+                source  => "puppet:///newrelic/RPM-GPG-KEY-NewRelic";
+            }
 
-      yumrepo { "newrelic":
-          baseurl     => "http://yum.newrelic.com/pub/newrelic/el5/\$basearch", 
-          enabled     => "1",
-          gpgcheck    => "1",
-          gpgkey      => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NewRelic";
-      }
+            yumrepo { "newrelic":
+                baseurl     => "http://yum.newrelic.com/pub/newrelic/el5/\$basearch",
+                enabled     => "1",
+                gpgcheck    => "1",
+                gpgkey      => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NewRelic";
+            }
+        }
     }
-  }
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -9,6 +9,12 @@ class newrelic::server {
         notify => Service['newrelic-sysmond'];
     }
 
+    exec { "newrelic-set-ssl":
+        unless  => "egrep -q ^ssl=true$ /etc/newrelic/nrsysmond.cfg",
+        command => "nrsysmond-config --set ssl=true",
+        notify => Service['newrelic-sysmond'];
+    }
+
     service { "newrelic-sysmond":
         enable  => true,
         ensure  => running,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,10 +1,10 @@
 class newrelic::server {
     include newrelic::package
 
-    if $newrelic_license == undef{ fail('$newrelic_license not defined') } 
+    if $newrelic_license == undef{ fail('$newrelic_license not defined') }
 
     exec { "newrelic-set-license":
-        unless  => "grep -q 'license_key=${newrelic_license}' /etc/newrelic/nrsysmond.cfg",
+        unless  => "egrep -q '^license_key=${newrelic_license}$' /etc/newrelic/nrsysmond.cfg",
         command => "nrsysmond-config --set license_key=${newrelic_license}",
         notify => Service['newrelic-sysmond'];
     }


### PR DESCRIPTION
- Don't use third-party apt module, instead manage the key/repo by hand. (The apt module that's currently required is not part of puppet like yum_repo, but from the rather common example42 set. We don't use it where I work, and I don't think it's good to require it as a dependency.)
- Improve pre-condition for config file updates
- Enable SSL in service configuration

Also includes some small documentation updates, whitespace trimming and a reindent of repo.pp to use 4-space tabs as per the other files.
