### PR TITLE
Make license a parameter to the newrelic class

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Installation
 1. Sign up for an account at http://newrelic.com/signup if you
    haven't yet.
 2. Copy this directory to your puppet master module path
-3. Set $newrelic_license and apply the `newrelic` class to any nodes you want the agent installed on:
-5. Login to your New Relic dashboard and you should see your servers show up
+3. Apply the `newrelic` class to any nodes you want the agent installed on: `class { 'newrelic': license => '<your license key'>' }`
+4. Login to your New Relic dashboard and you should see your servers show up
    in a few minutes.
 
 Contributing

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,4 @@
-class newrelic {
+class newrelic($license  = $::newrelic_license) {
     include newrelic::repo
     include newrelic::package
     include newrelic::server

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,5 +1,6 @@
 class newrelic::server {
     include newrelic::package
+    $newrelic_license = $newrelic::license
 
     if $newrelic_license == undef{ fail('$newrelic_license not defined') }
 


### PR DESCRIPTION
Replace use of global variable, `$newrelic_license`, with a `license`
paramter to the newrelic class.

Maintains backwards compatibility with use of global variable.
