### PR TITLE
Move Debian/Ubuntu specific exec definitions into corresponding branch

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,9 +1,9 @@
 class newrelic::repo {
-    Exec['newrelic-add-apt-key', 'newrelic-add-apt-repo', 'newrelic-apt-get-update'] {
-      path +> ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin']
-    }
     case $operatingsystem {
         /Debian|Ubuntu/: {
+            Exec['newrelic-add-apt-key', 'newrelic-add-apt-repo', 'newrelic-apt-get-update'] {
+                path +> ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin']
+            }
             exec { newrelic-add-apt-key:
                 unless  => "apt-key list | grep -q 1024D/548C16BF",
                 command => "apt-key adv --keyserver hkp://subkeys.pgp.net --recv-keys 548C16BF",


### PR DESCRIPTION
Else we got an error on Amazon linux:

err: Could not retrieve catalog from remote server: Error 400 on SERVER: Could not find resource(s) Exec[newrelic-apt-get-update], Exec[newrelic-add-apt-key], Exec[newrelic-add-apt-repo] for overriding on node
