### PR TITLE
Correct module path path for file resource

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -23,7 +23,7 @@ class newrelic::repo {
                 owner   => root,
                 group   => root,
                 mode    => 0644,
-                source  => "puppet:///newrelic/RPM-GPG-KEY-NewRelic";
+                source  => "puppet:///modules/newrelic/RPM-GPG-KEY-NewRelic";
             }
 
             yumrepo { "newrelic":


### PR DESCRIPTION
Normally this should throw a deprecation warning. Puppet expects file resources in modules to be prefixed with `puppet:///modules`:

http://docs.puppetlabs.com/puppet/3/reference/modules_fundamentals.html#files
