### PR TITLE
Use APT class to manage Debian & Ubuntu repositories

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,6 +1,6 @@
 # Class: newrelic::repo
 #
-# This module manages the newrelic apt repository
+# This module manages the Newrelic APT and YUM repositories
 #
 
 class newrelic::repo {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,36 +1,36 @@
+# Class: newrelic::repo
+#
+# This module manages the newrelic apt repository
+#
+
 class newrelic::repo {
+
+    # Add the New Relic apt repo source
     case $operatingsystem {
         /Debian|Ubuntu/: {
-            Exec['newrelic-add-apt-key', 'newrelic-add-apt-repo', 'newrelic-apt-get-update'] {
-                path +> ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin']
-            }
-            exec { newrelic-add-apt-key:
-                unless  => "apt-key list | grep -q 1024D/548C16BF",
-                command => "apt-key adv --keyserver hkp://subkeys.pgp.net --recv-keys 548C16BF",
-            }
-            exec { newrelic-add-apt-repo:
-                creates => "/etc/apt/sources.list.d/newrelic.list",
-                command => "wget -O /etc/apt/sources.list.d/newrelic.list http://download.newrelic.com/debian/newrelic.list",
-            }
-            exec { newrelic-apt-get-update:
-                refreshonly => true,
-                subscribe   => [Exec["newrelic-add-apt-key"], Exec["newrelic-add-apt-repo"]],
-                command     => "apt-get update",
-            }
+          apt::source { 'newrelic':
+            location          => 'http://apt.newrelic.com/debian/',
+            release           => 'newrelic',
+            repos             => 'non-free',
+            required_packages => 'debian-archive-keyring',
+            key               => '548C16BF',
+            key_server        => 'subkeys.pgp.net',
+            include_src       => false
+          }
         }
         default: {
-            file { "/etc/pki/rpm-gpg/RPM-GPG-KEY-NewRelic":
-                owner   => root,
-                group   => root,
-                mode    => 0644,
-                source  => "puppet:///modules/newrelic/RPM-GPG-KEY-NewRelic";
+            file { '/etc/pki/rpm-gpg/RPM-GPG-KEY-NewRelic':
+                owner   => 'root',
+                group   => 'root',
+                mode    => '0644',
+                source  => 'puppet:///modules/newrelic/RPM-GPG-KEY-NewRelic';
             }
 
-            yumrepo { "newrelic":
-                baseurl     => "http://yum.newrelic.com/pub/newrelic/el5/\$basearch",
-                enabled     => "1",
-                gpgcheck    => "1",
-                gpgkey      => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NewRelic";
+            yumrepo { 'newrelic':
+                baseurl     => 'http://yum.newrelic.com/pub/newrelic/el5/\$basearch',
+                enabled     => '1',
+                gpgcheck    => '1',
+                gpgkey      => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NewRelic';
             }
         }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,14 @@
+{ 
+	"name" : "puppet-newrelic",
+	"version" : "0.0.24",
+	"author" : "Joe Miller",
+	"summary" : "This puppet module will install New Relic's FREE Server monitor agent on your servers.",
+	"description" : "This puppet module will install New Relic's FREE Server monitor agent on your servers.",
+	"license" : "Apache License, Version 2.0",
+	"project_page" : "https://github.com/joemiller/puppet-newrelic",
+	"dependancies" : [
+		{ 	"name" : "puppetlabs-apt", 
+			"version_range" : ">= 1.4.2"
+		}
+	]
+}


### PR DESCRIPTION
The PuppetLabs APT class will ensure the repo is present, without running exec() every time. Have also applied some puppet-lint changes.
