### PR TITLE
Fix apt-key error

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -4,17 +4,25 @@ class newrelic::repo {
             Exec['newrelic-add-apt-key', 'newrelic-add-apt-repo', 'newrelic-apt-get-update'] {
                 path +> ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin']
             }
-            exec { newrelic-add-apt-key:
-                unless  => "apt-key list | grep -q 1024D/548C16BF",
-                command => "apt-key adv --keyserver hkp://subkeys.pgp.net --recv-keys 548C16BF",
-            }
             exec { newrelic-add-apt-repo:
                 creates => "/etc/apt/sources.list.d/newrelic.list",
                 command => "wget -O /etc/apt/sources.list.d/newrelic.list http://download.newrelic.com/debian/newrelic.list",
             }
+            exec { newrelic-get-apt-key:
+              command => 'wget -O newrelic_signing.key https://download.newrelic.com/548C16BF.gpg',
+              cwd => '/tmp/',
+              user => root,
+              creates => '/tmp/newrelic_signing.key',
+              require => Exec['newrelic-add-apt-repo'],
+            }
+            exec { newrelic-add-apt-key:
+              unless  => "apt-key list | grep -q 1024D/548C16BF",
+              command => "apt-key add newrelic_signing.key",
+              cwd => '/tmp/',
+              require => Exec['newrelic-get-apt-key'],
+            }
             exec { newrelic-apt-get-update:
-                refreshonly => true,
-                subscribe   => [Exec["newrelic-add-apt-key"], Exec["newrelic-add-apt-repo"]],
+                require   => [Exec["newrelic-add-apt-key"], Exec["newrelic-add-apt-repo"]],
                 command     => "apt-get update",
             }
         }


### PR DESCRIPTION
Hello,

I was running into an error on Ubuntu:

```
Error: apt-key adv --keyserver hkp://subkeys.pgp.net --recv-keys 548C16BF returned 2 instead of one of [0]
Error: /Stage[main]/Newrelic::Repo/Exec[newrelic-add-apt-key]/returns: change from notrun to 0 failed: apt-key adv --keyserver hkp://subkeys.pgp.net --recv-keys 548C16BF returned 2 instead of one of [0]
```

These changes should fix that. 

I also ended up having to change the sequence of the commands and enforce ordering with `require` in order to work around a Ubuntu 16.04 bug described [here](https://github.com/owncloud/client/issues/5287) and [here](https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1592040).

I believe #11 solves this same issue, however I didn't see anywhere that specifies what version of the apt module it needs, and I wasn't able to get it working with the versions I tried.